### PR TITLE
docs: add note about chmod +x for try.rb script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Instantly navigate through all your experiment directories with:
 ```bash
 curl -sL https://raw.githubusercontent.com/tobi/try/refs/heads/main/try.rb > ~/.local/try.rb
 
+# Make "try" executable so it can be run directly
+chmod +x ~/.local/try.rb
+
 # Add to your shell (bash/zsh)
 echo 'eval "$(~/.local/try.rb init ~/src/tries)"' >> ~/.zshrc
 ```


### PR DESCRIPTION
The downloaded `try.rb` script was not executable by default, causing a "permission denied" error when running it.

Added a step to `chmod +x ~/.local/try.rb` so the script can be executed directly.