### PR TITLE
Add Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,31 @@ export TRY_PATH=~/code/sketches
 
 Default: `~/src/tries`
 
+## Nix
+
+### Quick start
+
+```bash
+nix run github:tobi/try
+nix run github:tobi/try -- --help
+nix run github:tobi/try init ~/my-tries
+```
+
+### Home Manager
+
+```nix
+{
+  inputs.try.url = "github:tobi/try";
+  
+  imports = [ inputs.try.homeManagerModules.default ];
+  
+  programs.try = {
+    enable = true;
+    path = "~/experiments";  # optional, defaults to ~/src/tries
+  };
+}
+```
+
 ## Why Ruby?
 
 - One file, no dependencies

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755577059,
+        "narHash": "sha256-5hYhxIpco8xR+IpP3uU56+4+Bw7mf7EMyxS/HqUYHQY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97eb7ee0da337d385ab015a23e15022c865be75c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "try - fresh directories for every vibe";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      
+      flake = {
+        homeManagerModules.default = { config, lib, pkgs, ... }:
+          with lib;
+          let
+            cfg = config.programs.try;
+          in {
+            options.programs.try = {
+              enable = mkEnableOption "try - fresh directories for every vibe";
+              
+              package = mkOption {
+                type = types.package;
+                default = inputs.self.packages.${pkgs.system}.default;
+                description = "The try package to use.";
+              };
+              
+              path = mkOption {
+                type = types.str;
+                default = "~/src/tries";
+                description = "Path where try directories will be stored.";
+              };
+            };
+            
+            config = mkIf cfg.enable {
+              programs.bash.initExtra = mkIf config.programs.bash.enable ''
+                eval "$(${cfg.package}/bin/try init ${cfg.path})"
+              '';
+              
+              programs.zsh.initExtra = mkIf config.programs.zsh.enable ''
+                eval "$(${cfg.package}/bin/try init ${cfg.path})"
+              '';
+              
+              programs.fish.shellInit = mkIf config.programs.fish.enable ''
+                eval (${cfg.package}/bin/try init ${cfg.path})
+              '';
+            };
+          };
+      };
+      
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        packages.default = pkgs.stdenv.mkDerivation rec {
+          pname = "try";
+          version = "0.1.0";
+          
+          src = ./.;
+          
+          buildInputs = [ pkgs.ruby ];
+          
+          installPhase = ''
+            mkdir -p $out/bin
+            cp try.rb $out/bin/try
+            chmod +x $out/bin/try
+          '';
+          
+          meta = with pkgs.lib; {
+            description = "Fresh directories for every vibe - lightweight experiments for people with ADHD";
+            homepage = "https://github.com/tobi/try";
+            license = licenses.mit;
+            maintainers = [ ];
+            platforms = platforms.unix;
+          };
+        };
+        
+        apps.default = {
+          type = "app";
+          program = "${self'.packages.default}/bin/try";
+        };
+      };
+    };
+}


### PR DESCRIPTION
This enables Nix and NixOS users to easily try `try`.

This PR was [largely LLM generated](https://x.com/sridca/status/1958184431065203188) and I've [confirmed](https://github.com/srid/nixos-config/commit/51b9e9e178b5544089bd9477f97e2290b1306c66) it to work.