### PR TITLE
fixes broken create screen

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -557,10 +557,12 @@ class TrySelector
       # No name typed, prompt for one
       suggested_name = ""
 
-      STDERR.print("\e[2J\e[H\e[?25h")  # Clear, home, show cursor
+      UI.cls  # Clear screen using UI system
       UI.puts "{h2}Enter new try name"
-      UI.print "> {dim_text}#{date_prefix}-{reset}#{suggested_name}"
+      UI.puts
+      UI.puts "> {dim_text}#{date_prefix}-{reset}"
       UI.flush
+      STDERR.print("\e[?25h")
 
       entry = ""
       # Read user input in cooked mode


### PR DESCRIPTION
Some of the last commits broke the new screen

Before:
<img width="1070" height="703" alt="image" src="https://github.com/user-attachments/assets/608ed2eb-6ad0-4868-be9e-d09388b0a7a2" />


Now:

<img width="1070" height="703" alt="image" src="https://github.com/user-attachments/assets/8a029104-4c95-49c7-92a7-ec595030cb31" />
