### PR TITLE
Fix flake src path to use inputs.self instead of ./.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           pname = "try";
           version = "0.1.0";
 
-          src = ./.;
+          src = inputs.self;
 
           buildInputs = [ pkgs.ruby ];
 


### PR DESCRIPTION
## Summary
- Replace `src = ./.` with `src = inputs.self` in flake.nix
- Addresses Nix warning about performance and file copying optimization
- Makes the flake evaluation faster and copies fewer files

## Test plan
- [x] Verify the flake builds successfully with `nix build`
- [x] Verify the application runs correctly with `nix run . -- --help`
- [x] Confirm no functionality is broken
- [x] Verified warning appears on main branch before fix

🤖 Generated with [Claude Code](https://claude.ai/code)