### PR TITLE
Fix 'try clone` bug

### DIFF
--- a/tests/test_clone_and_url_name.rb
+++ b/tests/test_clone_and_url_name.rb
@@ -24,4 +24,13 @@ class TestCloneAndUrlName < Test::Unit::TestCase
       assert_match(/my-fork/, stdout, 'should use the provided custom name in path')
     end
   end
+
+  def test_cd_clone_wrapper_emits_clone_script
+    Dir.mktmpdir do |dir|
+      stdout, _stderr, _status = run_cmd('cd', 'clone', 'https://github.com/tobi/try.git', 'my-fork', '--path', dir)
+      assert_match(/mkdir -p '\S+my-fork'/, stdout)
+      assert_match(/git clone 'https:\/\/github\.com\/tobi\/try\.git' '\S+my-fork'/, stdout)
+      assert_match(/cd '\S+my-fork'/, stdout)
+    end
+  end
 end

--- a/tests/test_create_new_and_delete.rb
+++ b/tests/test_create_new_and_delete.rb
@@ -45,6 +45,8 @@ class TestCreateNewAndDelete < Test::Unit::TestCase
       second_dir = '2025-08-15-second'
       FileUtils.mkdir_p(File.join(dir, first_dir))
       FileUtils.mkdir_p(File.join(dir, second_dir))
+      # Bump mtime of the first directory so it appears first by recency
+      FileUtils.touch(File.join(dir, first_dir, '.mtime_bump'))
 
       # Test Ctrl-J (down) navigation - starts at index 0, goes to index 1 (second directory)
       stdout, _stderr, _status = run_cmd('cd', '--and-keys', 'CTRL-J,ENTER', '--path', dir)

--- a/try.rb
+++ b/try.rb
@@ -858,6 +858,7 @@ if __FILE__ == $0
       { type: 'mkdir' },
       { type: 'echo', msg: "Using {highlight}git clone{reset_fg} to create this trial from #{git_uri}." },
       { type: 'git-clone', uri: git_uri },
+      { type: 'touch'},
       { type: 'cd' }
     ]
   end
@@ -908,6 +909,10 @@ if __FILE__ == $0
   end
 
   def cmd_cd!(args, tries_path, and_type, and_exit, and_keys, and_confirm)
+    if args.first == "clone"
+      return cmd_clone!(args[1..-1] || [], tries_path)
+    end
+
     # Support: try . [name] and try ./path [name]
     if args.first && args.first.start_with?('.')
       path_arg = args.shift


### PR DESCRIPTION
When invoking the explicit `try clone` command via the CLI wrapper - it always calls the script as `cd`, so `try clone <uri> [name]` arrives as `cd clone <uri> [name]`. 

This caused `if is_git_uri?(search_term.split.first)` to always return false and resulted in the repo failing to clone and the folder names getting messed up.

The fix checks `args.first == "clone"` in `cmd_cd!` and if true it routes to `cmd_clone!` . 

Also included a flaky test fix in this PR and I added `{ type: 'touch'}` within the `cmd_clone!` method to ensure scoring logic works accurately.