### PR TITLE
Explicitly use Ruby to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -sL https://raw.githubusercontent.com/tobi/try/refs/heads/main/try.rb > ~/.
 chmod +x ~/.local/try.rb
 
 # Add to your shell (bash/zsh)
-echo 'eval "$(~/.local/try.rb init ~/src/tries)"' >> ~/.zshrc
+echo 'eval "$(ruby ~/.local/try.rb init ~/src/tries)"' >> ~/.zshrc
 
 # for fish shell users
 echo 'eval "$(~/.local/try.rb init ~/src/tries | string collect)"' >> ~/.config/fish/config.fish


### PR DESCRIPTION
My terminal is configured to open `.rb` using vim automatically, so the original script doesn't work. I've added `ruby` explicitly to the installation guide. I didn't update the fish instructions because IDK if that's possible to do in fish too.