### PR TITLE
Exclude .git and other hidden dirs from list of tries

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -187,7 +187,8 @@ class TrySelector
     @all_tries ||= begin
       tries = []
       Dir.foreach(@base_path) do |entry|
-        next if entry == '.' || entry == '..'
+        # exclude . and .. but also .git, and any other hidden dirs.
+        next if entry.start_with?('.')
 
         path = File.join(@base_path, entry)
         stat = File.stat(path)


### PR DESCRIPTION
I made `~/src/tries` a git repo and I don't like seeing `.git` in the list.