### PR TITLE
Eliminate unintended output in fish shell integration

### DIFF
--- a/tests/test_init_eval.rb
+++ b/tests/test_init_eval.rb
@@ -29,7 +29,7 @@ class TestInitEval < Test::Unit::TestCase
       assert_match(/^function try/m, stdout)
       assert_match(/cd --path \"#{Regexp.escape(File.expand_path(dir))}\"/, stdout)
       assert_match(/string collect\)/, stdout)
-      assert_match(/string match -r ' \&\& ' -- \$cmd/, stdout)
+      assert_match(/string match -rq ' \&\& ' -- \$cmd/, stdout)
     end
   end
 end

--- a/try.rb
+++ b/try.rb
@@ -906,7 +906,7 @@ if __FILE__ == $0
         end
         set -l rc $status
         if test $rc -eq 0
-          if string match -r ' && ' -- $cmd
+          if string match -rq ' && ' -- $cmd
             eval $cmd
           else
             printf %s $cmd


### PR DESCRIPTION
PR https://github.com/tobi/try/pull/39 makes fish shell integration operational.

However, when selecting an entry in `try`, an unintended output ` && `  displayed. This is happening because in fish shell `string match` outputs the matched substring. Explicitly suppressing the output (`-q` flag) resolves this.

The fix required a change in the fish shell integration, and also a unit test.