### PR TITLE
fix: update checksum

### DIFF
--- a/Formula/try.rb
+++ b/Formula/try.rb
@@ -2,7 +2,7 @@ class Try < Formula
   desc "Fresh directories for every vibe - lightweight experiments for people with ADHD"
   homepage "https://github.com/tobi/try"
   url "https://github.com/tobi/try/archive/refs/heads/main.tar.gz"
-  sha256 "dd3753f38b5c35597c8c2528a19efd7e4289bbbe977d18e2e299a2a57b393a8e"
+  sha256 "151778fdd07adac23fb021d2d84bd0756e0d626a97498503da24413bfdd72c28"
   version "main"
 
   depends_on "ruby"


### PR DESCRIPTION
Fixes https://github.com/tobi/try/issues/51

The checksum of the `main.tar.gz` seems has changed thus, home-brew installer is failing. This PR updates the correct checksum. Can confirm the brew can install try just fine as expected.
