### PR TITLE
Correcting bug in fish, the variable must be in the scope of the func…

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -900,9 +900,9 @@ if __FILE__ == $0
         # Check if first argument is a known command
         switch $argv[1]
           case clone worktree init
-            set -l cmd (/usr/bin/env ruby "$script_path"#{path_arg} $argv 2>/dev/tty | string collect)
+            set -f cmd (/usr/bin/env ruby "$script_path"#{path_arg} $argv 2>/dev/tty | string collect)
           case '*'
-            set -l cmd (/usr/bin/env ruby "$script_path" cd#{path_arg} $argv 2>/dev/tty | string collect)
+            set -f cmd (/usr/bin/env ruby "$script_path" cd#{path_arg} $argv 2>/dev/tty | string collect)
         end
         set -l rc $status
         if test $rc -eq 0


### PR DESCRIPTION
I tried running it in the latest version of fish and the "-l" parameter only works within the case, block scope. I changed it to the "-f" function scope parameter and it started working.