### PR TITLE
fix: fix the nix module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,8 +77,8 @@
             cp -r lib $out/bin/
             chmod +x $out/bin/try
 
-            wrapProgram $out/bin/try \
-              --prefix PATH : ${ruby}/bin
+            substituteInPlace $out/bin/try \
+              --replace '#!/usr/bin/env ruby' '#!${ruby}/bin/ruby'
           '';
 
           meta = with pkgs.lib; {


### PR DESCRIPTION
Fixes #60 

`try` installed with the home manager module failed because it references /usr/bin/ruby which is absent on nixos. This fix removes the calls to ruby that broke nixos installations, as well as patching the shebang at the beginning