### PR TITLE
fix(init): use parent process to detect shell, fallback to $SHELL

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -1300,7 +1300,10 @@ if __FILE__ == $0
 
   # shell detection for init wrapper
   def fish?
-    ENV['SHELL']&.include?('fish')
+    parent_shell = `ps c -p #{Process.ppid} -o 'ucomm='`.strip rescue nil
+    parent_shell = ENV["SHELL"] if parent_shell.to_s.empty?
+
+    parent_shell&.include?('fish')
   end
 
 


### PR DESCRIPTION
This PR fixes the `fish?` function to detect the actual shell process running the command, rather than relying on `$SHELL` (which only reflects the login shell)

### Problem:

The `fish?` function in `try.rb` checks `ENV['SHELL']` to detect the current shell:
```ruby
def fish?
  ENV['SHELL']&.include?('fish')
end
```

However, `ENV['SHELL']` is the login shell, not the current shell executing the command. this causes incorrect behavior when:

- fish login shell, running from zsh / bash. outputs fish syntax, which causes zsh / bash parse error
- zsh / bash login shell, running from fish. outputs zsh syntax, which causes fish syntax error

![Image](https://github.com/user-attachments/assets/e8e5a62c-e125-4f2a-9ccb-8aa8d8ae8bc1)

### Changes:

Detect current shell by checking parent process name, with fallback to $SHELL if detection fails or returns empty

```ruby
def fish?
  parent_shell = `ps c -p #{Process.ppid} -o 'ucomm='`.strip rescue nil
  parent_shell = ENV["SHELL"] if parent_shell.to_s.empty?
  
  parent_shell&.include?('fish')
end
```

Fix #68