### PR TITLE
Point formula to latest commit

### DIFF
--- a/Formula/try.rb
+++ b/Formula/try.rb
@@ -1,8 +1,8 @@
 class Try < Formula
   desc "Fresh directories for every vibe - lightweight experiments for people with ADHD"
   homepage "https://github.com/tobi/try"
-  url "https://github.com/tobi/try/archive/refs/heads/main.tar.gz"
-  sha256 "151778fdd07adac23fb021d2d84bd0756e0d626a97498503da24413bfdd72c28"
+  url "https://github.com/tobi/try/archive/08f70fa34761e308acc0546b723d038e41aa0fee.tar.gz"
+  sha256 "818b3c7f37410fe1bb719f5ae75d57a59808eef0e9ec36009a01e08ebfa3d558"
   version "main"
 
   depends_on "ruby"


### PR DESCRIPTION
## Problem
`brew install try` would give
```
✘ Formula try (main)                                                                                                            [Verifying   179.8KB/  0.0 B]
Error: Formula reports different checksum:  151778fdd07adac23fb021d2d84bd0756e0d626a97498503da24413bfdd72c28
       SHA-256 checksum of downloaded file: 2bd796fb0c5676403ef7c111ba49dcd0fdb8fc7e9848438afc34a4a32bfdd042
```

The formula was pointing to https://github.com/tobi/try/archive/refs/heads/main.tar.gz, which changes with every commit. This creates a chicken-and-egg issue — updating the SHA256 hash is itself a commit to main, which invalidates the hash you just set.

## Fix 
Point to a specific commit's archive instead. The commit SHA is immutable so the checksum stays valid forever, regardless of future commits.

Claude actually recommends:

> Note: The ideal long-term solution is to use tagged releases (e.g. v1.0.0). The commit SHA approach is a stable workaround until releases are set up.
