### PR TITLE
Export TRY_PATH env var from init output

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -1168,7 +1168,9 @@ if __FILE__ == $0
     end
 
     path_arg = tries_path ? " --path '#{tries_path}'" : ""
+    export_line = tries_path ? "export TRY_PATH='#{tries_path}'" : ""
     bash_or_zsh_script = <<~SHELL
+      #{export_line}
       try() {
         local out
         out=$(/usr/bin/env ruby '#{script_path}' exec#{path_arg} "$@" 2>/dev/tty)
@@ -1180,7 +1182,9 @@ if __FILE__ == $0
       }
     SHELL
 
+    fish_export = tries_path ? "set -gx TRY_PATH '#{tries_path}'" : ""
     fish_script = <<~SHELL
+      #{fish_export}
       function try
         set -l out (/usr/bin/env ruby '#{script_path}' exec#{path_arg} $argv 2>/dev/tty | string collect)
         if test $pipestatus[1] -eq 0


### PR DESCRIPTION
## Summary

- `try init` now exports `TRY_PATH` as an environment variable alongside the shell function
- Bash/zsh gets `export TRY_PATH='...'`, fish gets `set -gx TRY_PATH '...'`
- Allows other tools to discover the tries directory via `$TRY_PATH` without hardcoding paths

## Motivation

Other CLI tools want to place output into the tries directory when available. The path is already baked into the `--path` arg inside the function body, but isn't accessible to external tools. Exporting it as an env var makes it a public interface.

The variable is already read by try itself as input (`TRY_PATH=/foo try init`), so this just closes the loop by also setting it as output.

## Test plan

- [x] All existing tests pass
- [x] `try init ~/src/tries` outputs `export TRY_PATH='...'` before the function
- [x] `SHELL=/usr/bin/fish try init` outputs `set -gx TRY_PATH '...'` before the function