### PR TITLE
fix: handle `exec init` to prevent TUI on re-source

### DIFF
--- a/spec/tests/test_03_commands.sh
+++ b/spec/tests/test_03_commands.sh
@@ -26,6 +26,14 @@ else
     fail "exec clone should include cd" "contains cd command" "$output" "command_line.md#clone"
 fi
 
+# Test: exec init outputs shell function (regression: re-sourcing .zshrc)
+output=$(try_run --path="$TEST_TRIES" exec init "$TEST_TRIES" 2>&1)
+if echo "$output" | grep -q "try()"; then
+    pass
+else
+    fail "exec init should output shell function" "contains 'try()'" "$output" "command_line.md#init"
+fi
+
 # Test: exec cd is equivalent to exec (default command)
 output1=$(try_run --path="$TEST_TRIES" --and-keys=$'\r' exec 2>/dev/null)
 output2=$(try_run --path="$TEST_TRIES" --and-keys=$'\r' exec cd 2>/dev/null)

--- a/try.rb
+++ b/try.rb
@@ -1541,6 +1541,9 @@ if __FILE__ == $0
     when 'clone'
       ARGV.shift
       emit_script(cmd_clone!(ARGV, tries_path))
+    when 'init'
+      ARGV.shift
+      cmd_init!(ARGV, tries_path)
     when 'worktree'
       ARGV.shift
       repo = ARGV.shift

--- a/try.rb
+++ b/try.rb
@@ -1268,7 +1268,7 @@ if __FILE__ == $0
       fish_path_arg = explicit_path ? " --path '#{explicit_path}'" : " --path (if set -q TRY_PATH; echo \"$TRY_PATH\"; else; echo '#{default_path}'; end)"
       <<~FISH
         function try
-          set -l out (/usr/bin/env ruby '#{script_path}' exec#{fish_path_arg} $argv 2>/dev/tty | string collect)
+          set -l out ('#{script_path}' exec#{fish_path_arg} $argv 2>/dev/tty | string collect)
           if test $pipestatus[1] -eq 0
             eval $out
           else
@@ -1286,7 +1286,7 @@ if __FILE__ == $0
         function try {
           $tryPath = #{ps_path_expr}
           $tempErr = [System.IO.Path]::GetTempFileName()
-          $out = & ruby '#{script_path}' exec --path $tryPath @args 2>$tempErr
+          $out = & '#{script_path}' exec --path $tryPath @args 2>$tempErr
           if ($LASTEXITCODE -eq 0) {
             $out | Invoke-Expression
           } else {
@@ -1301,7 +1301,7 @@ if __FILE__ == $0
       <<~SH
         try() {
           local out
-          out=$(/usr/bin/env ruby '#{script_path}' exec#{path_arg} "$@" 2>/dev/tty)
+          out=$('#{script_path}' exec#{path_arg} "$@" 2>/dev/tty)
           if [ $? -eq 0 ]; then
             eval "$out"
           else


### PR DESCRIPTION
## Summary

### Fix 1: Handle `exec init` subcommand

- When re-sourcing `~/.zshrc`, the `try` shell function is already defined, so `try init ~/path` routes through the wrapper as `try exec init ~/path`
- The `exec` handler didn't have a case for `init`, causing it to fall through to the default TUI selector — triggering an unwanted interactive UI with search term `init-/path/to/tries`
- Added `when 'init'` to the `exec` subcommand dispatch so it correctly delegates to `cmd_init!`
- Added regression test in `spec/tests/test_03_commands.sh`

### Fix 2: Invoke script directly instead of via `/usr/bin/env ruby`

- The init shell function used `/usr/bin/env ruby` to invoke the script, which could resolve to the wrong Ruby version (e.g. system Ruby 2.6 lacking `Data.define` support)
- Changed to invoke the script path directly, letting the shebang determine which Ruby to use
- `script_path` is always `File.expand_path($0)` — the absolute path of the running script — so direct invocation is safe
- Applied to all three shell snippets: bash/zsh, fish, and PowerShell

## Reproduce

```zsh
# In ~/.zshrc:
eval "$(try init ~/Developer/tries)"

# First source works fine, second triggers TUI:
source ~/.zshrc  # ← interactive selector pops up
```

## Test plan

- [ ] `try init ~/path` still outputs shell function definition
- [ ] `try exec init ~/path` now also outputs shell function definition (instead of opening TUI)
- [ ] `source ~/.zshrc` can be run multiple times without triggering the selector
- [ ] Init snippet no longer contains `/usr/bin/env ruby`, uses script path directly