### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ Instantly navigate through all your experiment directories with:
 
 ## Installation
 
-### RubyGems (Recommended)
+### Recommended (RubyGems)
 
 ```bash
 gem install try-cli
 ```
 
+### Alternative Installations (Homebrew)
+
+```bash
+brew install try
+```
 Then add to your shell:
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1197,7 +1197,7 @@
       <p>— PREFER HOMEBREW? —</p>
       <div class="alt-methods">
         <div class="code-block">
-          <code>brew tap tobi/try https://github.com/tobi/try && brew install try</code>
+          <code>brew install try</code>
           <button class="copy-btn" onclick="copyCode(this)">Copy</button>
         </div>
       </div>


### PR DESCRIPTION
Removed the instructions for installing with a custom Tap.

Try is now [available](https://github.com/Homebrew/homebrew-core/commit/83814b22b231caee23ef0487269e8a31b85bc5fc) to install directly via [Homebrew](https://brew.sh/).