### PR TITLE
feat: allow disabling emoji output via --no-emoji / NO_EMOJI

### DIFF
--- a/lib/tui.rb
+++ b/lib/tui.rb
@@ -23,9 +23,10 @@ require "io/console"
 
 module Tui
   @colors_enabled = ENV["NO_COLORS"].to_s.empty?
+  @emoji_enabled = ENV["NO_EMOJI"].to_s.empty?
 
   class << self
-    attr_accessor :colors_enabled
+    attr_accessor :colors_enabled, :emoji_enabled
 
     def colors_enabled?
       @colors_enabled
@@ -37,6 +38,18 @@ module Tui
 
     def enable_colors!
       @colors_enabled = true
+    end
+
+    def emoji_enabled?
+      @emoji_enabled
+    end
+
+    def disable_emoji!
+      @emoji_enabled = false
+    end
+
+    def enable_emoji!
+      @emoji_enabled = true
     end
   end
 
@@ -299,9 +312,10 @@ module Tui
       SegmentWriter::FillSegment.new(char.to_s)
     end
 
-    # Use for emoji characters - precomputes width and enables fast-path
-    def emoji(char)
-      SegmentWriter::EmojiSegment.new(char)
+    # Use for emoji characters - precomputes width and enables fast-path.
+    # `trailing` is the gap after the icon, it disappears with the emoji when disabled.
+    def emoji(char, trailing = " ")
+      SegmentWriter::EmojiSegment.new(Tui.emoji_enabled? ? "#{char}#{trailing}" : "")
     end
   end
 

--- a/try.rb
+++ b/try.rb
@@ -331,7 +331,7 @@ class TrySelector
     width = screen.width
     height = screen.height
 
-    screen.header.add_line { |line| line.write << emoji("🏠") << Tui::Text.accent(" Try Directory Selection") }
+    screen.header.add_line { |line| line.write << emoji("🏠") << Tui::Text.accent("Try Directory Selection") }
     screen.header.add_line { |line| line.write.write_dim(fill("─")) }
     screen.header.add_line do |line|
       prefix = "Search: "
@@ -405,7 +405,7 @@ class TrySelector
     else
       emoji("📁")
     end
-    line.write << icon << " "
+    line.write << icon
 
     plain_name, rendered_name = formatted_entry_name(entry)
     prefix_width = 5
@@ -431,11 +431,11 @@ class TrySelector
     line.write << (is_selected ? Tui::Text.highlight("→ ") : "  ")
     date_prefix = Time.now.strftime("%Y-%m-%d")
     label = if @input_buffer.empty?
-      "📂 Create new: #{date_prefix}-"
+      "Create new: #{date_prefix}-"
     else
-      "📂 Create new: #{date_prefix}-#{@input_buffer}"
+      "Create new: #{date_prefix}-#{@input_buffer}"
     end
-    line.write << label
+    line.write << emoji("📂") << label
   end
 
   def formatted_entry_name(entry)
@@ -594,12 +594,12 @@ class TrySelector
     screen = Tui::Screen.new(io: STDERR)
 
     screen.header.add_line do |line|
-      line.center << emoji("✏️") << Tui::Text.accent("  Rename directory")
+      line.center << emoji("✏️", "  ") << Tui::Text.accent("Rename directory")
     end
     screen.header.add_line { |line| line.write.write_dim(fill("─")) }
 
     screen.body.add_line do |line|
-      line.write << emoji("📁") << " #{current_name}"
+      line.write << emoji("📁") << current_name
     end
 
     # Add empty lines, then centered input prompt
@@ -716,12 +716,12 @@ class TrySelector
     screen = Tui::Screen.new(io: STDERR)
 
     screen.header.add_line do |line|
-      line.center << emoji("🚀") << Tui::Text.accent("  Graduate try to project")
+      line.center << emoji("🚀", "  ") << Tui::Text.accent("Graduate try to project")
     end
     screen.header.add_line { |line| line.write.write_dim(fill("─")) }
 
     screen.body.add_line do |line|
-      line.write << emoji("📁") << " #{current_name}"
+      line.write << emoji("📁") << current_name
     end
     screen.body.add_line
 
@@ -885,13 +885,13 @@ class TrySelector
 
     count = marked_items.length
     screen.header.add_line do |line|
-      line.center << emoji("🗑️") << Tui::Text.accent("  Delete #{count} #{count == 1 ? 'directory' : 'directories'}?")
+      line.center << emoji("🗑️", "  ") << Tui::Text.accent("Delete #{count} #{count == 1 ? 'directory' : 'directories'}?")
     end
     screen.header.add_line { |line| line.write.write_dim(fill("─")) }
 
     marked_items.each do |item|
       screen.body.add_line(background: Tui::Palette::DANGER_BG) do |line|
-        line.write << emoji("🗑️") << " #{item[:basename]}"
+        line.write << emoji("🗑️") << item[:basename]
       end
     end
 
@@ -1012,6 +1012,11 @@ if __FILE__ == $0
   Tui.disable_colors! if disable_colors
   Tui.disable_colors! if ENV['NO_COLOR'] && !ENV['NO_COLOR'].empty?
 
+  disable_emoji = ARGV.delete('--no-emoji')
+
+  Tui.disable_emoji! if disable_emoji
+  Tui.disable_emoji! if ENV['NO_EMOJI'] && !ENV['NO_EMOJI'].empty?
+
   # Global help: show for --help/-h anywhere
   if ARGV.include?("--help") || ARGV.include?("-h")
     print_global_help
@@ -1087,7 +1092,7 @@ if __FILE__ == $0
   and_exit = !!ARGV.delete('--and-exit')
   and_keys_raw = extract_option_with_value!(ARGV, '--and-keys')
   and_confirm = extract_option_with_value!(ARGV, '--and-confirm')
-  # Note: --no-expand-tokens and --no-colors are processed early (before --help check)
+  # Note: --no-expand-tokens, --no-colors, and --no-emoji are processed early (before --help check)
 
   command = ARGV.shift
 


### PR DESCRIPTION
## Summary

Adds `--no-emoji` flag and `NO_EMOJI` env var so users on terminals without emoji glyphs, or anyone who prefers plain-text output can turn emoji output off. Mirrors the existing `--no-colors` / `NO_COLOR` implementation 1:1

```bash
try                         # renders with emoji as before
try --no-emoji              # no emoji anywhere
NO_EMOJI=1 try              # no emoji anywhere
```

## Changes

- Adds `Tui.disable_emoji!` / `enable_emoji!` / `emoji_enabled?`, wired into the `emoji()` helper so every icon returns an empty segment when disabled
- `emoji()` gains an optional trailing-padding argument so the space after each icon vanishes alongside it — no orphaned leading spaces

Emoji-enabled output is byte-identical to `main`

## Samples

#### With emoji (default)
[
<img width="3024" height="928" alt="Screenshot 2026-04-24 at 14 15 58" src="https://github.com/user-attachments/assets/dac73ba5-8311-416e-b239-26ea03513672" />
](url)
#### Without emoji (`NO_EMOJI=1` / `--no-emoji`)
<img width="3024" height="928" alt="Screenshot 2026-04-24 at 14 16 13" src="https://github.com/user-attachments/assets/1315e742-f353-416d-b2c6-cb6e4f1b4de5" />
