### PR TITLE
Support nested scp-style clone URLs

### DIFF
--- a/spec/command_line.md
+++ b/spec/command_line.md
@@ -77,6 +77,9 @@ try https://github.com/tobi/try.git
 
 try clone git@github.com:tobi/try.git
 # SSH URL also works: 2025-11-30-tobi-try
+
+try clone deploy@git.example.com:src/team/project.git
+# SCP-style SSH URLs with nested paths also work: 2025-11-30-deploy-project
 ```
 
 ### worktree

--- a/spec/tests/test_32_git_uri.sh
+++ b/spec/tests/test_32_git_uri.sh
@@ -6,66 +6,74 @@ section "git-uri"
 # Test: SSH git@github.com format
 output=$(try_run --path="$TEST_TRIES" exec clone git@github.com:user/myrepo 2>&1)
 if echo "$output" | grep -q "user-myrepo"; then
-    pass
+	pass
 else
-    fail "SSH git@github.com should parse user/repo" "user-myrepo" "$output" "git_uri"
+	fail "SSH git@github.com should parse user/repo" "user-myrepo" "$output" "git_uri"
 fi
 
 # Test: SSH with .git suffix stripping (directory name should not contain .git)
 output=$(try_run --path="$TEST_TRIES" exec clone git@github.com:user/myrepo.git 2>&1)
 # The cd target path should end with user-myrepo, not user-myrepo.git
 if echo "$output" | grep -qE "cd '.*user-myrepo'"; then
-    pass
+	pass
 else
-    fail "SSH clone should strip .git suffix from directory name" "cd path ends with user-myrepo" "$output" "git_uri"
+	fail "SSH clone should strip .git suffix from directory name" "cd path ends with user-myrepo" "$output" "git_uri"
 fi
 
 # Test: Non-GitHub HTTPS host (gitlab.com)
 output=$(try_run --path="$TEST_TRIES" exec clone https://gitlab.com/user/glrepo 2>&1)
 if echo "$output" | grep -q "user-glrepo"; then
-    pass
+	pass
 else
-    fail "HTTPS gitlab.com should parse user/repo" "user-glrepo" "$output" "git_uri"
+	fail "HTTPS gitlab.com should parse user/repo" "user-glrepo" "$output" "git_uri"
 fi
 
 # Test: Non-GitHub SSH host
 output=$(try_run --path="$TEST_TRIES" exec clone git@gitlab.com:user/sshrepo 2>&1)
 if echo "$output" | grep -q "user-sshrepo"; then
-    pass
+	pass
 else
-    fail "SSH gitlab.com should parse user/repo" "user-sshrepo" "$output" "git_uri"
+	fail "SSH gitlab.com should parse user/repo" "user-sshrepo" "$output" "git_uri"
+fi
+
+# Test: SCP-style SSH host with custom user and nested path
+output=$(try_run --path="$TEST_TRIES" exec clone deploy@git.example.com:src/team/project.git 2>&1)
+if echo "$output" | grep -q "deploy-project"; then
+	pass
+else
+	fail "SCP-style SSH URL should parse nested repo path" "deploy-project" "$output" "git_uri"
 fi
 
 # Test: Unparseable URI produces error
 output=$(try_run --path="$TEST_TRIES" exec clone not-a-valid-uri 2>&1)
 exit_code=$?
 if [ $exit_code -ne 0 ]; then
-    pass
+	pass
 else
-    fail "Unparseable URI should produce error exit" "non-zero exit code" "exit=$exit_code output=$output" "git_uri"
+	fail "Unparseable URI should produce error exit" "non-zero exit code" "exit=$exit_code output=$output" "git_uri"
 fi
 
 # Test: is_git_uri detects gitlab.com
 output=$(try_run --path="$TEST_TRIES" exec https://gitlab.com/user/repo 2>&1)
 if echo "$output" | grep -q "git clone"; then
-    pass
+	pass
 else
-    fail "gitlab.com URL should be detected as git URI" "git clone" "$output" "git_uri"
+	fail "gitlab.com URL should be detected as git URI" "git clone" "$output" "git_uri"
 fi
 
 # Test: is_git_uri detects .git suffix
 output=$(try_run --path="$TEST_TRIES" exec https://example.com/user/repo.git 2>&1)
 if echo "$output" | grep -q "git clone"; then
-    pass
+	pass
 else
-    fail ".git suffix should be detected as git URI" "git clone" "$output" "git_uri"
+	fail ".git suffix should be detected as git URI" "git clone" "$output" "git_uri"
 fi
 
 # Test: Shell quoting with special characters in path
 output=$(try_run --path="$TEST_TRIES" exec clone https://github.com/user/repo 2>&1)
 # q() wraps in single quotes; check output uses single-quoted paths
 if echo "$output" | grep -qE "cd '.*repo'"; then
-    pass
+	pass
 else
-    fail "Clone output should use single-quoted paths" "single-quoted cd" "$output" "git_uri"
+	fail "Clone output should use single-quoted paths" "single-quoted cd" "$output" "git_uri"
 fi

--- a/try.rb
+++ b/try.rb
@@ -1057,6 +1057,11 @@ if __FILE__ == $0
       # git@host:user/repo
       host, user, repo = $1, $2, $3
       return { user: user, repo: repo, host: host }
+    elsif uri.match(%r{^([^@/:]+)@([^:]+):(.+)})
+      # SCP-style SSH: user@host:path/to/repo
+      user, host, path = $1, $2, $3
+      repo = File.basename(path)
+      return { user: user, repo: repo, host: host }
     else
       return nil
     end


### PR DESCRIPTION
## Summary
- Accept generic scp-style SSH clone URLs such as `user@host:path/to/repo.git`
- Preserve existing `git@host:user/repo` directory naming behavior
- Document and test nested scp-style clone URL handling

## Testing
- `./spec/tests/runner.sh ./try.rb test_32_git_uri`