### PR TITLE
Support nested scp-style clone URLs

### DIFF
--- a/spec/command_line.md
+++ b/spec/command_line.md
@@ -77,6 +77,9 @@ try https://github.com/tobi/try.git
 
 try clone git@github.com:tobi/try.git
 # SSH URL also works: 2025-11-30-tobi-try
+
+try clone deploy@git.example.com:src/team/project.git
+# SCP-style SSH URLs with nested paths also work: 2025-11-30-deploy-project
 ```
 
 ### worktree

--- a/spec/tests/test_32_git_uri.sh
+++ b/spec/tests/test_32_git_uri.sh
@@ -36,6 +36,14 @@ else
     fail "SSH gitlab.com should parse user/repo" "user-sshrepo" "$output" "git_uri"
 fi
 
+# Test: SCP-style SSH host with custom user and nested path
+output=$(try_run --path="$TEST_TRIES" exec clone deploy@git.example.com:src/team/project.git 2>&1)
+if echo "$output" | grep -q "deploy-project"; then
+    pass
+else
+    fail "SCP-style SSH URL should parse nested repo path" "deploy-project" "$output" "git_uri"
+fi
+
 # Test: Unparseable URI produces error
 output=$(try_run --path="$TEST_TRIES" exec clone not-a-valid-uri 2>&1)
 exit_code=$?

--- a/try.rb
+++ b/try.rb
@@ -1057,6 +1057,11 @@ if __FILE__ == $0
       # git@host:user/repo
       host, user, repo = $1, $2, $3
       return { user: user, repo: repo, host: host }
+    elsif uri.match(%r{^([^@/:]+)@([^:]+):(.+)})
+      # SCP-style SSH: user@host:path/to/repo
+      user, host, path = $1, $2, $3
+      repo = File.basename(path)
+      return { user: user, repo: repo, host: host }
     else
       return nil
     end


### PR DESCRIPTION
## Summary
- Accept generic scp-style SSH clone URLs such as `user@host:path/to/repo.git`
- Preserve existing `git@host:user/repo` directory naming behavior
- Document and test nested scp-style clone URL handling

## Testing
- `./spec/tests/runner.sh ./try.rb test_32_git_uri`