### PR TITLE
feat: add support for SSH git URL with custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ever find yourself with 50 directories named `test`, `test2`, `new-test`, `actua
 
 **try** is here for your beautifully chaotic mind.
 
-# What it does 
+# What it does
 
 ![Fuzzy Search Demo](assets/try-fuzzy-search-demo.gif)
 
@@ -162,6 +162,7 @@ Supported git URI formats:
 - `git@github.com:user/repo.git` (SSH GitHub)
 - `https://gitlab.com/user/repo.git` (GitLab)
 - `git@host.com:user/repo.git` (SSH other hosts)
+- `ssh://git@host.com:port/user/repo.git` (SSH other hosts with custom port)
 
 The `.git` suffix is automatically removed from URLs when generating directory names.
 
@@ -199,9 +200,9 @@ nix run github:tobi/try init ~/my-tries
 ```nix
 {
   inputs.try.url = "github:tobi/try";
-  
+
   imports = [ inputs.try.homeManagerModules.default ];
-  
+
   programs.try = {
     enable = true;
     path = "~/experiments";  # optional, defaults to ~/src/tries

--- a/spec/command_line.md
+++ b/spec/command_line.md
@@ -77,6 +77,9 @@ try https://github.com/tobi/try.git
 
 try clone git@github.com:tobi/try.git
 # SSH URL also works: 2025-11-30-tobi-try
+
+try clone ssh://git@yourgitserver:port/user/repo.git
+# SSH URL with custom port also works: 2025-11-30-user-repo
 ```
 
 ### worktree

--- a/spec/tests/test_32_git_uri.sh
+++ b/spec/tests/test_32_git_uri.sh
@@ -36,6 +36,14 @@ else
     fail "SSH gitlab.com should parse user/repo" "user-sshrepo" "$output" "git_uri"
 fi
 
+# Test: Other SSH host with custom port
+output=$(try_run --path="$TEST_TRIES" exec clone ssh://git@git_host:port/user/customsshrepo.git 2>&1)
+if echo "$output" | grep -q "user-customsshrepo"; then
+    pass
+else
+    fail "SSH git_host:port should parse user/customsshrepo" "user-customsshrepo" "$output" "git_uri"
+fi
+
 # Test: Unparseable URI produces error
 output=$(try_run --path="$TEST_TRIES" exec clone not-a-valid-uri 2>&1)
 exit_code=$?

--- a/try.rb
+++ b/try.rb
@@ -1057,6 +1057,10 @@ if __FILE__ == $0
       # git@host:user/repo
       host, user, repo = $1, $2, $3
       return { user: user, repo: repo, host: host }
+    elsif uri.match(%r{^ssh://git@([^/]+)/([^/]+)/([^/]+)})
+      # ssh://git@host:port/user/repo
+      host, user, repo = $1, $2, $3
+      return { user: user, repo: repo, host: host }
     else
       return nil
     end


### PR DESCRIPTION
When using a custom git server listening on a custom ssh port, the URL format is not

`git@host:user/repo.git`
but
`ssh://git@host:port/user/repo.git`

This commit allows such URLs to be parsed.

Tests have been updated. This works well at my company using a Bitbucket with SSH listening behind a load balancer on port 443 