### PR TITLE
fix: preserve full custom name with spaces when using `try clone`

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -816,7 +816,7 @@ class TrySelector
       full_path = File.join(@base_path, final_name)
 
       @selected = { type: :mkdir, path: full_path }
-      end
+    end
   end
 
   def confirm_batch_delete(tries)
@@ -1152,7 +1152,7 @@ if __FILE__ == $0
 
   def cmd_clone!(args, tries_path)
     git_uri = args.shift
-    custom_name = args.shift
+    custom_name = args.join(" ")
 
     unless git_uri
       warn "Error: git URI required for clone command"


### PR DESCRIPTION
fixes: #114