### PR TITLE
fix: preserve Nix Ruby in init wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,16 +69,13 @@
           version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./VERSION);
 
           src = inputs.self;
-          nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-
           installPhase = ''
             mkdir -p $out/bin
             cp try.rb $out/bin/try
             cp -r lib $out/bin/
+            substituteInPlace $out/bin/try \
+              --replace-fail '#!/usr/bin/env ruby' '#!${ruby}/bin/ruby'
             chmod +x $out/bin/try
-
-            wrapProgram $out/bin/try \
-              --prefix PATH : ${ruby}/bin
           '';
 
           meta = with pkgs.lib; {

--- a/spec/init_spec.md
+++ b/spec/init_spec.md
@@ -35,6 +35,7 @@ try() {
 
 Key elements:
 - Function name: `try`
+- Calls the resolved `try` executable directly, relying on its shebang or package wrapper
 - Captures `try exec` output to local variable
 - Redirects stderr to `/dev/tty` (TUI renders to stderr)
 - Exit code 0: Evaluates the output (executes cd, git clone, etc.)
@@ -56,10 +57,10 @@ end
 ## Path Embedding
 
 The init output must embed:
-1. The full path to the `try` binary (resolved at init time)
+1. The full path to the `try` binary (resolved at init time; a canonical store path is acceptable when invoked through a symlink)
 2. The default tries path (typically `~/src/tries`)
 
-This ensures the wrapper always calls the correct binary regardless of `$PATH` changes.
+This ensures the wrapper always calls the correct binary regardless of `$PATH` changes, while preserving executable shebangs and package-level launchers.
 
 ## Installation Instructions
 

--- a/spec/tests/test_14_init_shells.sh
+++ b/spec/tests/test_14_init_shells.sh
@@ -26,10 +26,18 @@ else
     fail "init with fish should emit fish function" "function try" "$output" "init_spec.md"
 fi
 
-# Test: init output contains the real, full path to try binary
+# Test: init output contains a real, full path to the try binary
 output=$(SHELL=/bin/bash try_run init "$TEST_TRIES" 2>&1)
-if echo "$output" | grep -qF "$TRY_BIN_PATH"; then
+TRY_BIN_REAL_PATH=$(realpath "$TRY_BIN_PATH" 2>/dev/null || readlink -f "$TRY_BIN_PATH" 2>/dev/null || echo "$TRY_BIN_PATH")
+if echo "$output" | grep -qF "$TRY_BIN_PATH" || echo "$output" | grep -qF "$TRY_BIN_REAL_PATH"; then
     pass
 else
-    fail "init should contain real, full path to try binary" "$TRY_BIN_PATH" "$output" "init_spec.md"
+    fail "init should contain real, full path to try binary" "$TRY_BIN_PATH or $TRY_BIN_REAL_PATH" "$output" "init_spec.md"
+fi
+
+# Test: init output calls the binary wrapper directly, not the wrapped Ruby script
+if echo "$output" | grep -qE "/usr/bin/env ruby|/ruby |\.try-wrapped"; then
+    fail "init should not bypass package wrappers" "no /usr/bin/env ruby and no .try-wrapped" "$output" "init_spec.md"
+else
+    pass
 fi

--- a/try.rb
+++ b/try.rb
@@ -1268,7 +1268,7 @@ if __FILE__ == $0
       fish_path_arg = explicit_path ? " --path '#{explicit_path}'" : " --path (if set -q TRY_PATH; echo \"$TRY_PATH\"; else; echo '#{default_path}'; end)"
       <<~FISH
         function try
-          set -l out (/usr/bin/env ruby '#{script_path}' exec#{fish_path_arg} $argv 2>/dev/tty | string collect)
+          set -l out ('#{script_path}' exec#{fish_path_arg} $argv 2>/dev/tty | string collect)
           if test $pipestatus[1] -eq 0
             eval $out
           else
@@ -1286,7 +1286,7 @@ if __FILE__ == $0
         function try {
           $tryPath = #{ps_path_expr}
           $tempErr = [System.IO.Path]::GetTempFileName()
-          $out = & ruby '#{script_path}' exec --path $tryPath @args 2>$tempErr
+          $out = & '#{script_path}' exec --path $tryPath @args 2>$tempErr
           if ($LASTEXITCODE -eq 0) {
             $out | Invoke-Expression
           } else {
@@ -1301,7 +1301,7 @@ if __FILE__ == $0
       <<~SH
         try() {
           local out
-          out=$(/usr/bin/env ruby '#{script_path}' exec#{path_arg} "$@" 2>/dev/tty)
+          out=$('#{script_path}' exec#{path_arg} "$@" 2>/dev/tty)
           if [ $? -eq 0 ]; then
             eval "$out"
           else


### PR DESCRIPTION
## Problem

The Nix/Home Manager install path generated a broken shell function from `try init`.

`try` needs to install a shell function because a subprocess cannot `cd` the parent shell. That function captures `try exec` output and evals it.

Before this change, the generated function invoked the Ruby script explicitly through the ambient Ruby:

```sh
out=$(/usr/bin/env ruby '/nix/store/.../bin/.try-wrapped' exec ...)
```

For Nix builds, `wrapProgram` installs:

```text
bin/try          # wrapper that sets PATH to include Nix Ruby
bin/.try-wrapped # actual Ruby script
```

When `try init` runs under that wrapper, `$0` resolves to the internal `.try-wrapped` script. The emitted shell function therefore bypasses `bin/try`, which means it also bypasses the Nix-provided Ruby. On macOS this falls back to the system Ruby, which is too old for the current code and fails at runtime.

In short:

```text
works:  bin/try -> Nix Ruby -> Ruby script
breaks: /usr/bin/env ruby -> .try-wrapped
```

## Fix

This removes the wrapper layer from the Nix package and makes the generated shell function call the resolved executable directly.

Changes:

- `try init` now emits direct executable calls:

  ```sh
  out=$('/path/to/try' exec ...)
  ```

  instead of:

  ```sh
  out=$(/usr/bin/env ruby '/path/to/try' exec ...)
  ```

- The Nix derivation no longer uses `wrapProgram`.
- The Nix derivation patches the installed script shebang to the packaged Ruby:

  ```ruby
  #!/nix/store/...-ruby-3.3.x/bin/ruby
  ```

As a result, the Nix package contains a single public executable script:

```text
bin/try
```

There is no `.try-wrapped`, no package-specific logic in the Ruby code, and the shell integration preserves the executable selected by the installer/package manager.

## Tests

```sh
nix build .
./spec/tests/runner.sh ./result/bin/try
```

Result:

```text
388/388 passed
```
