### PR TITLE
Fix selected row contrast on light terminal themes

### DIFF
--- a/lib/tui.rb
+++ b/lib/tui.rb
@@ -90,14 +90,14 @@ module Tui
   module Palette
     HEADER      = ANSI.sgr(1, "38;5;114")
     ACCENT      = ANSI.sgr(1, "38;5;214")
-    HIGHLIGHT   = "\e[1;33m"  # Bold yellow (matches C version)
+    HIGHLIGHT   = "\e[1m"  # Bold only, no fixed color: readable on any theme
     MUTED       = ANSI.fg(245)
     MATCH       = ANSI.sgr(1, "38;5;226")
     INPUT_HINT  = ANSI.fg(244)
     INPUT_CURSOR_ON  = "\e[7m"
     INPUT_CURSOR_OFF = "\e[27m"
 
-    SELECTED_BG = ANSI.bg(238)
+    SELECTED_BG = "\e[7m"  # reverse video: adapts to terminal's own colors, not just dark themes
     DANGER_BG   = ANSI.bg(52)
   end
 


### PR DESCRIPTION
## Summary
- `SELECTED_BG` was hardcoded to a dark 256-color gray (`\e[48;5;238m`), and `HIGHLIGHT` used bold yellow — a combination tuned for dark terminal themes.
- On light themes (e.g. Ghostty's Melange Light), the theme's yellow ANSI color is a dark orange meant to read against a light background. Forced against `try`'s hardcoded dark selected-row background, it becomes nearly unreadable — the current row's fuzzy-match text disappears.
- Switched `SELECTED_BG` to reverse video (`\e[7m`), which swaps whatever fg/bg the terminal is already using instead of assuming dark. Dropped the fixed yellow from `HIGHLIGHT` in favor of bold-only, so the match emphasis doesn't reintroduce the same fixed-color contrast problem on top of the reversed background.

## Test plan
- [x] `ruby -c lib/tui.rb`
- [x] Ran `try` interactively with a light terminal theme (Ghostty Melange Light) — selected row and fuzzy match are now clearly readable
- [ ] Maintainer to confirm no regression on dark themes