### PR TITLE
fix: support nested SCP-style clone URLs

### DIFF
--- a/spec/command_line.md
+++ b/spec/command_line.md
@@ -81,6 +81,9 @@ try clone git@github.com:tobi/try.git
 
 try clone ssh://git@yourgitserver:port/user/repo.git
 # SSH URL with custom port also works: 2025-11-30-user-repo
+
+try clone deploy@git.example.com:src/team/project.git
+# SCP-style SSH URLs with nested paths also work: 2025-11-30-deploy-project
 ```
 
 ### worktree

--- a/spec/tests/test_32_git_uri.sh
+++ b/spec/tests/test_32_git_uri.sh
@@ -44,6 +44,22 @@ else
     fail "SSH git_host:port should parse user/customsshrepo" "user-customsshrepo" "$output" "git_uri"
 fi
 
+# Test: SCP-style SSH host with custom user and nested path
+output=$(try_run --path="$TEST_TRIES" exec clone deploy@git.example.com:src/team/project.git 2>&1)
+if echo "$output" | grep -q "deploy-project"; then
+    pass
+else
+    fail "SCP-style SSH URL should parse nested repo path" "deploy-project" "$output" "git_uri"
+fi
+
+# Test: git@ SSH host with a nested path
+output=$(try_run --path="$TEST_TRIES" exec clone git@git.example.com:src/team/project.git 2>&1)
+if echo "$output" | grep -q "src-project"; then
+    pass
+else
+    fail "git@ SSH URL should parse nested repo path" "src-project" "$output" "git_uri"
+fi
+
 # Test: Unparseable URI produces error
 output=$(try_run --path="$TEST_TRIES" exec clone not-a-valid-uri 2>&1)
 exit_code=$?

--- a/try.rb
+++ b/try.rb
@@ -1053,13 +1053,20 @@ if __FILE__ == $0
       # https://gitlab.com/user/repo or other git hosts
       host, user, repo = $1, $2, $3
       return { user: user, repo: repo, host: host }
-    elsif uri.match(%r{^git@([^:]+):([^/]+)/([^/]+)})
-      # git@host:user/repo
-      host, user, repo = $1, $2, $3
+    elsif uri.match(%r{^git@([^:]+):([^/]+)/(.+)})
+      # git@host:user/path/to/repo
+      host, user, path = $1, $2, $3
+      repo = File.basename(path)
       return { user: user, repo: repo, host: host }
-    elsif uri.match(%r{^ssh://git@([^/]+)/([^/]+)/([^/]+)})
-      # ssh://git@host:port/user/repo
-      host, user, repo = $1, $2, $3
+    elsif uri.match(%r{^ssh://[^@/]+@([^/]+)/([^/]+)/(.+)})
+      # ssh://user@host:port/user/repo
+      host, user, path = $1, $2, $3
+      repo = File.basename(path)
+      return { user: user, repo: repo, host: host }
+    elsif uri.match(%r{^([^@/:]+)@([^:]+):(.+)})
+      # SCP-style SSH: user@host:path/to/repo
+      user, host, path = $1, $2, $3
+      repo = File.basename(path)
       return { user: user, repo: repo, host: host }
     else
       return nil


### PR DESCRIPTION
Closes #112

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>