### PR TITLE
Strip and -Os the Spinel native binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,16 @@ i: install ## Shortcut for install
 
 # Native binary via Spinel (optional)
 SPINEL ?= spinel
-NATIVE  = dist/try
+SPINEL_FLAGS ?= -O s
+NATIVE = dist/try
 
 .PHONY: native native-test
 native: $(NATIVE)
 
 $(NATIVE): try.rb lib/tui.rb lib/fuzzy.rb
 	mkdir -p dist
-	$(SPINEL) try.rb -o $(NATIVE)
+	$(SPINEL) $(SPINEL_FLAGS) try.rb -o $(NATIVE)
+	strip $(NATIVE)
 
 native-test: $(NATIVE)
 	bash spec/tests/runner.sh $(NATIVE)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ echo '~/.local/try.rb init ~/src/tries | source' >> ~/.config/fish/config.fish
 Compile a native `try` with [Spinel](https://github.com/matz/spinel). Build Spinel from source; [PR 3906](https://github.com/matz/spinel/pull/3906) is required so `IO#tty?` / `#winsize` work on handles that are not statically typed IO.
 
 ```bash
-make native SPINEL=/path/to/spinel
+make native SPINEL=/path/to/spinel   # -O s, then strip
 ./dist/try --help
 eval "$(./dist/try init)"   # wires the shell function to the binary, not MRI
 make native-test SPINEL=/path/to/spinel


### PR DESCRIPTION
## Summary
Stacked on #130. Makes `make native` emit a smaller release binary:

- `SPINEL_FLAGS ?= -O s` (Spinel wants `-O LEVEL` as two args)
- `strip` after link

`dist/try` went from **1,038,656** (unstripped `-O2`) to **696,584** (−33%). `.text` 924 KB → 661 KB.

Hyperfine vs stripped `-O2` was noise on `--help` / small TUI; 1000-dir scan 9.8 vs 9.4 ms. `-O3` was larger and only ~0.5 ms faster on that scan.

`make native-test` still **397/397**.

```
SPINEL ?= spinel
SPINEL_FLAGS ?= -O s
NATIVE = dist/try

$(NATIVE): try.rb lib/tui.rb lib/fuzzy.rb
	mkdir -p dist
	$(SPINEL) $(SPINEL_FLAGS) try.rb -o $(NATIVE)
	strip $(NATIVE)
```