### PR TITLE
fix: make `try init` re-source safe through the shell wrapper

### DIFF
--- a/spec/init_spec.md
+++ b/spec/init_spec.md
@@ -89,6 +89,14 @@ The wrapper interprets `try exec` exit codes:
 | 0 | Success | `eval` the output (execute shell commands) |
 | 1 | Cancelled/Error | Print the output (show message to user) |
 
+## Re-sourcing Safety
+
+The shell wrapper shadows the `try` binary. When a shell config is sourced
+again (`source ~/.zshrc`), `try init` must dispatch to the init logic through
+the wrapper and re-emit the function definition — never fall through to the
+interactive selector. `try exec init [PATH]` must therefore behave like
+`try init [PATH]`.
+
 ## Testing
 
 Test that init produces valid shell syntax:

--- a/spec/tests/test_36_shell_eval.sh
+++ b/spec/tests/test_36_shell_eval.sh
@@ -32,6 +32,17 @@ else
     fail "bash try exec should produce script with directory" "2025-01-01-hello" "$bash_out" "init_spec.md"
 fi
 
+# Test: `try exec init PATH` re-emits the wrapper with the new path.
+# The shell wrapper shadows the binary, so a re-source (`source ~/.zshrc`)
+# routes `try init` through `exec`; it must dispatch to init, not the selector.
+mkdir -p "$EVAL_DIR/other"
+bash_out=$("$TRY_BIN_PATH" exec --path "$EVAL_DIR" init "$EVAL_DIR/other" 2>/dev/null)
+if echo "$bash_out" | grep -qF -- "--path '$EVAL_DIR/other'"; then
+    pass
+else
+    fail "bash exec init should re-emit wrapper with new path" "--path '$EVAL_DIR/other'" "$bash_out" "init_spec.md"
+fi
+
 # --- zsh ---
 
 if command -v zsh >/dev/null 2>&1; then
@@ -55,6 +66,14 @@ if command -v zsh >/dev/null 2>&1; then
         pass
     else
         fail "zsh try exec should produce script with directory" "2025-01-01-hello" "$zsh_out" "init_spec.md"
+    fi
+
+    # Test: zsh exec init re-emits wrapper with new path (re-source safe)
+    zsh_out=$("$TRY_BIN_PATH" exec --path "$EVAL_DIR" init "$EVAL_DIR/other" 2>/dev/null)
+    if echo "$zsh_out" | grep -qF -- "--path '$EVAL_DIR/other'"; then
+        pass
+    else
+        fail "zsh exec init should re-emit wrapper with new path" "--path '$EVAL_DIR/other'" "$zsh_out" "init_spec.md"
     fi
 else
     pass  # skip

--- a/try.rb
+++ b/try.rb
@@ -1683,6 +1683,12 @@ if $0 == __FILE__ || TryCompat.compiled_binary?
     when 'clone'
       ARGV.shift
       emit_script(cmd_clone!(ARGV, tries_path))
+    when 'init'
+      # Re-sourcing support: the shell wrapper shadows the binary, so a
+      # second `try init` (e.g. from `source ~/.zshrc`) must re-emit the
+      # wrapper instead of falling through to the interactive selector.
+      ARGV.shift
+      cmd_init!(ARGV, tries_path)
     when 'worktree'
       ARGV.shift
       repo = ARGV.shift


### PR DESCRIPTION
## What

Route `try exec init` to the init logic so re-running `try init` from a sourced shell re-emits the wrapper instead of opening the interactive selector.

## Why

The shell wrapper generated by `try init` shadows the `try` binary. When a shell config is sourced again (`source ~/.zshrc`), the `try init` line now resolves to the wrapper, which calls `try exec` — and `exec` had no `init` case, falling through to the interactive selector with `init <path>` as the search query.

## Changes

- `try.rb`: dispatch `init` in the `exec` subcommand path, mirroring plain `try init` behavior.
- `spec/tests/test_36_shell_eval.sh`: regression tests for bash and zsh asserting `try exec init PATH` re-emits the wrapper with the new path.
- `spec/init_spec.md`: document re-sourcing safety.

> Note: #105 (zzzhizhia) covers the same `exec init` dispatch and has been open since March 2026. This PR is an independent implementation with additional bash/zsh regression coverage in `test_36_shell_eval.sh` and `init_spec.md` documentation. Happy to close this one if #105 is preferred.